### PR TITLE
#15 - Add a function to print a derivative tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,9 @@ enable_testing()
 
 include( ${CMAKE_SOURCE_DIR}/cmake/functions.cmake )
 
+set(LIBRARY_OUTPUT_PATH "${CMAKE_BINARY_DIR}/bin")
+set(EXECUTABLE_OUTPUT_PATH "${CMAKE_BINARY_DIR}/bin")
+
 add_subdirectory( derivative_tree )
 add_subdirectory( graph )
 add_subdirectory( operators )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ enable_testing()
 
 include( ${CMAKE_SOURCE_DIR}/cmake/functions.cmake )
 
+add_subdirectory( derivative_tree )
 add_subdirectory( graph )
 add_subdirectory( operators )
 add_subdirectory( query_tree )

--- a/derivative_tree/CMakeLists.txt
+++ b/derivative_tree/CMakeLists.txt
@@ -39,5 +39,6 @@ set_target_properties(
 
 target_link_libraries(
    ${target}
+   jymbooperators
    jymbotypes
 )

--- a/derivative_tree/include/derivative_tree.hpp
+++ b/derivative_tree/include/derivative_tree.hpp
@@ -1,9 +1,29 @@
 #ifndef DERIVATIVE_TREE_HEADER
 #define DERIVATIVE_TREE_HEADER
 
+#include "jymbo_types.hpp"
+#include "operators.hpp"
+
+#include <iostream>
+#include <string>
+
 namespace derivative_tree
 {
-   
+   struct printFrontierNode_t
+   {
+      // The node's ID in the tree.
+      int nodeId;
+
+      // Parentheses count
+      int parenthesesCount;
+
+      // The node's child ID - for a binary tree this is:
+      //    0: left child
+      //    1: right child
+      int childId;
+   };
+
+   void print(const jymbo::types::DerivativeTree & q_tree);
 }
 
 #endif

--- a/derivative_tree/include/derivative_tree.hpp
+++ b/derivative_tree/include/derivative_tree.hpp
@@ -23,7 +23,7 @@ namespace derivative_tree
       int childId;
    };
 
-   void print(const jymbo::types::DerivativeTree & q_tree);
+   void print(const jymbo::types::DerivativeTree & d_tree);
 }
 
 #endif

--- a/derivative_tree/src/derivative_tree.cpp
+++ b/derivative_tree/src/derivative_tree.cpp
@@ -3,4 +3,76 @@
 namespace derivative_tree
 {
    
+   void print(const jymbo::types::DerivativeTree & q_tree)
+   {
+      std::string out_string;
+      std::vector<printFrontierNode_t> frontier;
+
+      frontier.reserve(q_tree.size());
+
+      const int root_node_id = q_tree.getRootId();
+
+      printFrontierNode_t root_frontier_node;
+      root_frontier_node.childId = 0;
+      root_frontier_node.parenthesesCount = 0;
+      root_frontier_node.nodeId = root_node_id;
+
+      frontier.push_back(root_frontier_node);
+
+      while (!frontier.empty())
+      {
+         const printFrontierNode_t frontier_node = frontier.back();
+         frontier.pop_back();
+
+         const jymbo::types::DerivativeTree::MetaNode_T & tree_node = \
+            q_tree.getNode(frontier_node.nodeId);
+
+         if (frontier_node.childId == 1)
+         {
+            out_string += std::string(",");
+         }
+
+         if (tree_node.meta.nodeType == jymbo::types::enumDerivativeNodeType_t::kOperator)
+         {
+            out_string += jymbo::operatorToString(tree_node.meta.op);
+            out_string += std::string("(");
+         }
+         else if (tree_node.meta.nodeType == jymbo::types::enumDerivativeNodeType_t::kSymbol)
+         {
+            out_string += std::string(tree_node.meta.symbol.name);
+         }
+         else if (tree_node.meta.nodeType == jymbo::types::enumDerivativeNodeType_t::kSymbol)
+         {
+            out_string += std::string("Q");
+            out_string += std::to_string(tree_node.meta.qNodeId);
+         }
+
+         if (tree_node.childNodeIds[0] == -1 || tree_node.childNodeIds[1] == -1)
+         {
+            if (frontier_node.childId == 1)
+            {
+               for (int i = 0; i < frontier_node.parenthesesCount; ++i)
+               {
+                  out_string += std::string(")");
+               }
+            }
+            continue;
+         }
+
+         printFrontierNode_t left_frontier_node;
+         left_frontier_node.childId = 0;
+         left_frontier_node.parenthesesCount = 0;
+         left_frontier_node.nodeId = tree_node.childNodeIds[0];
+
+         printFrontierNode_t right_frontier_node;
+         right_frontier_node.childId = 1;
+         right_frontier_node.parenthesesCount = frontier_node.parenthesesCount + 1;
+         right_frontier_node.nodeId = tree_node.childNodeIds[1];
+
+         frontier.push_back(right_frontier_node);
+         frontier.push_back(left_frontier_node);
+      }
+
+      std::cout << out_string << "\n";
+   }
 }

--- a/derivative_tree/src/derivative_tree.cpp
+++ b/derivative_tree/src/derivative_tree.cpp
@@ -3,14 +3,14 @@
 namespace derivative_tree
 {
    
-   void print(const jymbo::types::DerivativeTree & q_tree)
+   void print(const jymbo::types::DerivativeTree & d_tree)
    {
       std::string out_string;
       std::vector<printFrontierNode_t> frontier;
 
-      frontier.reserve(q_tree.size());
+      frontier.reserve(d_tree.size());
 
-      const int root_node_id = q_tree.getRootId();
+      const int root_node_id = d_tree.getRootId();
 
       printFrontierNode_t root_frontier_node;
       root_frontier_node.childId = 0;
@@ -25,7 +25,7 @@ namespace derivative_tree
          frontier.pop_back();
 
          const jymbo::types::DerivativeTree::MetaNode_T & tree_node = \
-            q_tree.getNode(frontier_node.nodeId);
+            d_tree.getNode(frontier_node.nodeId);
 
          if (frontier_node.childId == 1)
          {
@@ -41,7 +41,7 @@ namespace derivative_tree
          {
             out_string += std::string(tree_node.meta.symbol.name);
          }
-         else if (tree_node.meta.nodeType == jymbo::types::enumDerivativeNodeType_t::kSymbol)
+         else if (tree_node.meta.nodeType == jymbo::types::enumDerivativeNodeType_t::kReference)
          {
             out_string += std::string("Q");
             out_string += std::to_string(tree_node.meta.qNodeId);

--- a/operators/src/operators.cpp
+++ b/operators/src/operators.cpp
@@ -59,16 +59,16 @@ namespace jymbo
       // that are equivalent to the derivative of the addition operator.
 
       jymbo::types::derivativeNode_t add_op;
-      add_op.node_type = jymbo::types::enumDerivativeNodeType_t::kOperator;
+      add_op.nodeType = jymbo::types::enumDerivativeNodeType_t::kOperator;
       add_op.op = jymbo::types::enumOperatorType_t::kAddition;
 
-      if (d_tree[d_node_id].node_type != jymbo::types::enumDerivativeNodeType_t::kReference)
+      if (d_tree[d_node_id].nodeType != jymbo::types::enumDerivativeNodeType_t::kReference)
       {
          std::cout << "Derivative tree at node id " << d_node_id << " should reference the q-tree, but it doesn't\n";
          return {{-1, -1}};
       }
 
-      const auto & q_node_ref = q_tree.getNode(d_tree[d_node_id].q_node_id);
+      const auto & q_node_ref = q_tree.getNode(d_tree[d_node_id].qNodeId);
 
       const int q_left_child_id = q_node_ref.childNodeIds[0];
       const int q_right_child_id = q_node_ref.childNodeIds[1];
@@ -79,12 +79,12 @@ namespace jymbo
       }
 
       jymbo::types::derivativeNode_t left_q_ref;
-      left_q_ref.node_type = jymbo::types::enumDerivativeNodeType_t::kReference;
-      left_q_ref.q_node_id = q_left_child_id;
+      left_q_ref.nodeType = jymbo::types::enumDerivativeNodeType_t::kReference;
+      left_q_ref.qNodeId = q_left_child_id;
 
       jymbo::types::derivativeNode_t right_q_ref;
-      right_q_ref.node_type = jymbo::types::enumDerivativeNodeType_t::kReference;
-      right_q_ref.q_node_id = q_right_child_id;
+      right_q_ref.nodeType = jymbo::types::enumDerivativeNodeType_t::kReference;
+      right_q_ref.qNodeId = q_right_child_id;
 
       d_tree[d_node_id] = add_op;
 
@@ -105,16 +105,16 @@ namespace jymbo
    )
    {
       jymbo::types::derivativeNode_t subtract_op;
-      subtract_op.node_type = jymbo::types::enumDerivativeNodeType_t::kOperator;
+      subtract_op.nodeType = jymbo::types::enumDerivativeNodeType_t::kOperator;
       subtract_op.op = jymbo::types::enumOperatorType_t::kSubtraction;
 
-      if (d_tree[d_node_id].node_type != jymbo::types::enumDerivativeNodeType_t::kReference)
+      if (d_tree[d_node_id].nodeType != jymbo::types::enumDerivativeNodeType_t::kReference)
       {
          std::cout << "Derivative tree at node id " << d_node_id << " should reference the q-tree, but it doesn't\n";
          return {{-1, -1}};
       }
 
-      const auto & q_node_ref = q_tree.getNode(d_tree[d_node_id].q_node_id);
+      const auto & q_node_ref = q_tree.getNode(d_tree[d_node_id].qNodeId);
 
       const int q_left_child_id = q_node_ref.childNodeIds[0];
       const int q_right_child_id = q_node_ref.childNodeIds[1];
@@ -125,12 +125,12 @@ namespace jymbo
       }
 
       jymbo::types::derivativeNode_t left_q_ref;
-      left_q_ref.node_type = jymbo::types::enumDerivativeNodeType_t::kReference;
-      left_q_ref.q_node_id = q_left_child_id;
+      left_q_ref.nodeType = jymbo::types::enumDerivativeNodeType_t::kReference;
+      left_q_ref.qNodeId = q_left_child_id;
 
       jymbo::types::derivativeNode_t right_q_ref;
-      right_q_ref.node_type = jymbo::types::enumDerivativeNodeType_t::kReference;
-      right_q_ref.q_node_id = q_right_child_id;
+      right_q_ref.nodeType = jymbo::types::enumDerivativeNodeType_t::kReference;
+      right_q_ref.qNodeId = q_right_child_id;
 
       d_tree[d_node_id] = subtract_op;
 
@@ -151,20 +151,20 @@ namespace jymbo
    )
    {
       jymbo::types::derivativeNode_t add_op;
-      add_op.node_type = jymbo::types::enumDerivativeNodeType_t::kOperator;
+      add_op.nodeType = jymbo::types::enumDerivativeNodeType_t::kOperator;
       add_op.op = jymbo::types::enumOperatorType_t::kAddition;
 
       jymbo::types::derivativeNode_t mult_op;
-      mult_op.node_type = jymbo::types::enumDerivativeNodeType_t::kOperator;
+      mult_op.nodeType = jymbo::types::enumDerivativeNodeType_t::kOperator;
       mult_op.op = jymbo::types::enumOperatorType_t::kMultiplication;
 
-      if (d_tree[d_node_id].node_type != jymbo::types::enumDerivativeNodeType_t::kReference)
+      if (d_tree[d_node_id].nodeType != jymbo::types::enumDerivativeNodeType_t::kReference)
       {
          std::cout << "Derivative tree at node id " << d_node_id << " should reference the q-tree, but it doesn't\n";
          return {{-1, -1}};
       }
 
-      const auto & q_node_ref = q_tree.getNode(d_tree[d_node_id].q_node_id);
+      const auto & q_node_ref = q_tree.getNode(d_tree[d_node_id].qNodeId);
 
       const int q_left_child_id = q_node_ref.childNodeIds[0];
       const int q_right_child_id = q_node_ref.childNodeIds[1];
@@ -175,12 +175,12 @@ namespace jymbo
       }
 
       jymbo::types::derivativeNode_t left_q_ref;
-      left_q_ref.node_type = jymbo::types::enumDerivativeNodeType_t::kReference;
-      left_q_ref.q_node_id = q_left_child_id;
+      left_q_ref.nodeType = jymbo::types::enumDerivativeNodeType_t::kReference;
+      left_q_ref.qNodeId = q_left_child_id;
 
       jymbo::types::derivativeNode_t right_q_ref;
-      right_q_ref.node_type = jymbo::types::enumDerivativeNodeType_t::kReference;
-      right_q_ref.q_node_id = q_right_child_id;
+      right_q_ref.nodeType = jymbo::types::enumDerivativeNodeType_t::kReference;
+      right_q_ref.qNodeId = q_right_child_id;
 
       d_tree[d_node_id] = add_op;
 
@@ -209,20 +209,20 @@ namespace jymbo
    )
    {
       jymbo::types::derivativeNode_t mult_op;
-      mult_op.node_type = jymbo::types::enumDerivativeNodeType_t::kOperator;
+      mult_op.nodeType = jymbo::types::enumDerivativeNodeType_t::kOperator;
       mult_op.op = jymbo::types::enumOperatorType_t::kMultiplication;
 
       jymbo::types::derivativeNode_t subtract_op;
-      subtract_op.node_type = jymbo::types::enumDerivativeNodeType_t::kOperator;
+      subtract_op.nodeType = jymbo::types::enumDerivativeNodeType_t::kOperator;
       subtract_op.op = jymbo::types::enumOperatorType_t::kSubtraction;
 
-      if (d_tree[d_node_id].node_type != jymbo::types::enumDerivativeNodeType_t::kReference)
+      if (d_tree[d_node_id].nodeType != jymbo::types::enumDerivativeNodeType_t::kReference)
       {
          std::cout << "Derivative tree at node id " << d_node_id << " should reference the q-tree, but it doesn't\n";
          return {{-1, -1}};
       }
 
-      const auto & q_node_ref = q_tree.getNode(d_tree[d_node_id].q_node_id);
+      const auto & q_node_ref = q_tree.getNode(d_tree[d_node_id].qNodeId);
 
       const int q_left_child_id = q_node_ref.childNodeIds[0];
       const int q_right_child_id = q_node_ref.childNodeIds[1];
@@ -233,12 +233,12 @@ namespace jymbo
       }
 
       jymbo::types::derivativeNode_t left_q_ref;
-      left_q_ref.node_type = jymbo::types::enumDerivativeNodeType_t::kReference;
-      left_q_ref.q_node_id = q_left_child_id;
+      left_q_ref.nodeType = jymbo::types::enumDerivativeNodeType_t::kReference;
+      left_q_ref.qNodeId = q_left_child_id;
 
       jymbo::types::derivativeNode_t right_q_ref;
-      right_q_ref.node_type = jymbo::types::enumDerivativeNodeType_t::kReference;
-      right_q_ref.q_node_id = q_right_child_id;
+      right_q_ref.nodeType = jymbo::types::enumDerivativeNodeType_t::kReference;
+      right_q_ref.qNodeId = q_right_child_id;
 
       d_tree[d_node_id] = subtract_op;
 
@@ -246,20 +246,20 @@ namespace jymbo
       const int right_mult_op_id = d_tree.addChild(d_node_id, mult_op);
 
       jymbo::types::derivativeNode_t pow_op;
-      pow_op.node_type = jymbo::types::enumDerivativeNodeType_t::kOperator;
+      pow_op.nodeType = jymbo::types::enumDerivativeNodeType_t::kOperator;
       pow_op.op = jymbo::types::enumOperatorType_t::kPower;
 
       const int left_frontier_node_id = d_tree.addChild(left_mult_op_id, left_q_ref);
       const int left_pow_op_id = d_tree.addChild(left_mult_op_id, pow_op);
 
       jymbo::types::derivativeNode_t neg_1_param;
-      neg_1_param.node_type = jymbo::types::enumDerivativeNodeType_t::kSymbol;
+      neg_1_param.nodeType = jymbo::types::enumDerivativeNodeType_t::kSymbol;
       neg_1_param.symbol = jymbo::initializeSymbol(
          "-1", -1, -1.f, jymbo::types::enumSymbolType_t::kParameter
       );
 
       jymbo::types::derivativeNode_t neg_2_param;
-      neg_2_param.node_type = jymbo::types::enumDerivativeNodeType_t::kSymbol;
+      neg_2_param.nodeType = jymbo::types::enumDerivativeNodeType_t::kSymbol;
       neg_2_param.symbol = jymbo::initializeSymbol(
          "-2", -2, -2.f, jymbo::types::enumSymbolType_t::kParameter
       );
@@ -292,24 +292,24 @@ namespace jymbo
    )
    {
       jymbo::types::derivativeNode_t subtract_op;
-      subtract_op.node_type = jymbo::types::enumDerivativeNodeType_t::kOperator;
+      subtract_op.nodeType = jymbo::types::enumDerivativeNodeType_t::kOperator;
       subtract_op.op = jymbo::types::enumOperatorType_t::kSubtraction;
 
       jymbo::types::derivativeNode_t mult_op;
-      mult_op.node_type = jymbo::types::enumDerivativeNodeType_t::kOperator;
+      mult_op.nodeType = jymbo::types::enumDerivativeNodeType_t::kOperator;
       mult_op.op = jymbo::types::enumOperatorType_t::kMultiplication;
 
       jymbo::types::derivativeNode_t pow_op;
-      pow_op.node_type = jymbo::types::enumDerivativeNodeType_t::kOperator;
+      pow_op.nodeType = jymbo::types::enumDerivativeNodeType_t::kOperator;
       pow_op.op = jymbo::types::enumOperatorType_t::kPower;
 
-      if (d_tree[d_node_id].node_type != jymbo::types::enumDerivativeNodeType_t::kReference)
+      if (d_tree[d_node_id].nodeType != jymbo::types::enumDerivativeNodeType_t::kReference)
       {
          std::cout << "Derivative tree at node id " << d_node_id << " should reference the q-tree, but it doesn't\n";
          return {{-1, -1}};
       }
 
-      const auto & q_node_ref = q_tree.getNode(d_tree[d_node_id].q_node_id);
+      const auto & q_node_ref = q_tree.getNode(d_tree[d_node_id].qNodeId);
 
       const int q_left_child_id = q_node_ref.childNodeIds[0];
       const int q_right_child_id = q_node_ref.childNodeIds[1];
@@ -320,12 +320,12 @@ namespace jymbo
       }
 
       jymbo::types::derivativeNode_t left_q_ref;
-      left_q_ref.node_type = jymbo::types::enumDerivativeNodeType_t::kReference;
-      left_q_ref.q_node_id = q_left_child_id;
+      left_q_ref.nodeType = jymbo::types::enumDerivativeNodeType_t::kReference;
+      left_q_ref.qNodeId = q_left_child_id;
 
       jymbo::types::derivativeNode_t right_q_ref;
-      right_q_ref.node_type = jymbo::types::enumDerivativeNodeType_t::kReference;
-      right_q_ref.q_node_id = q_right_child_id;
+      right_q_ref.nodeType = jymbo::types::enumDerivativeNodeType_t::kReference;
+      right_q_ref.qNodeId = q_right_child_id;
 
       d_tree[d_node_id] = mult_op;
 
@@ -339,7 +339,7 @@ namespace jymbo
       const int subtract_node_id = d_tree.addChild(pow_node_id, subtract_op);
 
       jymbo::types::derivativeNode_t pos_1_param;
-      pos_1_param.node_type = jymbo::types::enumDerivativeNodeType_t::kSymbol;
+      pos_1_param.nodeType = jymbo::types::enumDerivativeNodeType_t::kSymbol;
       pos_1_param.symbol = jymbo::initializeSymbol(
          "1", 1, 1.f, jymbo::types::enumSymbolType_t::kParameter
       );

--- a/tests/derivative_tree/derivative_tree_tests/CMakeLists.txt
+++ b/tests/derivative_tree/derivative_tree_tests/CMakeLists.txt
@@ -5,6 +5,8 @@ set(
 
 set(
    lib_links
+   jymboderivativetree
+   jymbosymbols
    jymbotypes
 )
 

--- a/tests/derivative_tree/derivative_tree_tests/derivative_tree_tests.cpp
+++ b/tests/derivative_tree/derivative_tree_tests/derivative_tree_tests.cpp
@@ -1,4 +1,6 @@
 #include "jymbo_types.hpp"
+#include "derivative_tree.hpp"
+#include "symbols.hpp"
 
 #define CATCH_CONFIG_MAIN
 
@@ -7,8 +9,41 @@
 TEST_CASE( "derivative_tree_instantiation", "[DerivativeTree]" )
 {
    jymbo::types::derivativeNode_t d_node;
-   d_node.node_type = jymbo::types::enumDerivativeNodeType_t::kOperator;
+   d_node.nodeType = jymbo::types::enumDerivativeNodeType_t::kOperator;
    d_node.op = jymbo::types::enumOperatorType_t::kEqual;
    jymbo::types::DerivativeTree d_tree(d_node);
    REQUIRE( true );
+}
+
+TEST_CASE( "print derivative tree", "[DerivativeTree]" )
+{
+   jymbo::types::derivativeNode_t d_node;
+   d_node.nodeType = jymbo::types::enumDerivativeNodeType_t::kOperator;
+   d_node.op = jymbo::types::enumOperatorType_t::kEqual;
+   jymbo::types::DerivativeTree d_tree(d_node);
+
+   jymbo::types::derivativeNode_t q_y_node;
+   q_y_node.nodeType = jymbo::types::enumDerivativeNodeType_t::kSymbol;
+   q_y_node.symbol = jymbo::initializeSymbol(
+      "y", 0, 0.f, jymbo::types::enumSymbolType_t::kDependent
+   );
+
+   jymbo::types::derivativeNode_t divide_op;
+   divide_op.nodeType = jymbo::types::enumDerivativeNodeType_t::kOperator;
+   divide_op.op = jymbo::types::enumOperatorType_t::kDivision;
+
+   jymbo::types::derivativeNode_t left_query_ref;
+   left_query_ref.nodeType = jymbo::types::enumDerivativeNodeType_t::kReference;
+   left_query_ref.qNodeId = 0;
+
+   jymbo::types::derivativeNode_t right_query_ref;
+   right_query_ref.nodeType = jymbo::types::enumDerivativeNodeType_t::kReference;
+   right_query_ref.qNodeId = 1;
+
+   d_tree.addChild(d_tree.getRootId(), q_y_node);
+   const int divide_op_id = d_tree.addChild(d_tree.getRootId(), divide_op);
+   d_tree.addChild(divide_op_id, left_query_ref);
+   d_tree.addChild(divide_op_id, right_query_ref);
+
+   derivative_tree::print(d_tree);
 }

--- a/types/jymbo_types.hpp
+++ b/types/jymbo_types.hpp
@@ -71,10 +71,10 @@ namespace types
       {
          symbol_t symbol;
          enumOperatorType_t op;
-         int q_node_id;
+         int qNodeId;
       };
 
-      enumDerivativeNodeType_t node_type;
+      enumDerivativeNodeType_t nodeType;
    };
 
    typedef graph::NAryTree<queryNode_t, 2> QueryTree;


### PR DESCRIPTION
## Features

- Copies and pastes the entire query tree print function and adds an else-if statement for printing references to query-tree nodes
- Changes field names in `derivativeNode_t` to camel case

Closes #15 
