### PR TITLE
#21 - Added functions to convert a d-tree to a q-tree

### DIFF
--- a/derivative_tree/include/derivative_tree.hpp
+++ b/derivative_tree/include/derivative_tree.hpp
@@ -24,11 +24,11 @@ namespace derivative_tree
 
    struct copyFrontierNode_t
    {
-      // The ID of the node from the source tree being added as a child to
-      // a destination tree's parent node ID.
+      // The ID of a node on a source tree being added as a child to a
+      // destination tree's parent node ID.
       int srcNodeId;
 
-      // The ID of the node on the destination tree that is adopting the node
+      // The ID of a node on a destination tree that is adopting the node
       // from the source tree.
       int destParentNodeId;
    };
@@ -40,6 +40,16 @@ namespace derivative_tree
    void derivatize(
       const jymbo::types::QueryTree & q_tree,
       jymbo::types::DerivativeTree & d_tree
+   );
+
+   // Copies a subtree from src_q_tree to dest_q_tree. The subtree from the
+   // input tree starting at node ID 'src_node_id' is copied to the location
+   // 'dest_node_id' on the output tree.
+   void copyQTreeToQTree(
+      const int src_node_id,
+      const int dest_node_id,
+      const jymbo::types::QueryTree & src_q_tree,
+      jymbo::types::QueryTree & dest_q_tree
    );
 
    jymbo::types::queryNode_t convertDNodeToQNode(

--- a/derivative_tree/include/derivative_tree.hpp
+++ b/derivative_tree/include/derivative_tree.hpp
@@ -22,6 +22,17 @@ namespace derivative_tree
       int childId;
    };
 
+   struct copyFrontierNode_t
+   {
+      // The ID of the node from the source tree being added as a child to
+      // a destination tree's parent node ID.
+      int srcNodeId;
+
+      // The ID of the node on the destination tree that is adopting the node
+      // from the source tree.
+      int destParentNodeId;
+   };
+
    void print(const jymbo::types::DerivativeTree & d_tree);
 
    std::string queryNodeToString(const jymbo::types::queryNode_t & q_node);
@@ -32,8 +43,7 @@ namespace derivative_tree
    );
 
    jymbo::types::queryNode_t convertDNodeToQNode(
-      const jymbo::types::derivativeNode_t d_node,
-      const jymbo::types::QueryTree & q_tree_in
+      const jymbo::types::derivativeNode_t d_node
    );
 
    void convertToQTree(

--- a/derivative_tree/include/derivative_tree.hpp
+++ b/derivative_tree/include/derivative_tree.hpp
@@ -30,6 +30,11 @@ namespace derivative_tree
       const jymbo::types::QueryTree & q_tree,
       jymbo::types::DerivativeTree & d_tree
    );
+
+   void convertToQTree(
+      const jymbo::types::DerivativeTree & d_tree,
+      jymbo::types::QueryTree & q_tree
+   );
 }
 
 #endif

--- a/derivative_tree/include/derivative_tree.hpp
+++ b/derivative_tree/include/derivative_tree.hpp
@@ -31,9 +31,15 @@ namespace derivative_tree
       jymbo::types::DerivativeTree & d_tree
    );
 
+   jymbo::types::queryNode_t convertDNodeToQNode(
+      const jymbo::types::derivativeNode_t d_node,
+      const jymbo::types::QueryTree & q_tree_in
+   );
+
    void convertToQTree(
       const jymbo::types::DerivativeTree & d_tree,
-      jymbo::types::QueryTree & q_tree
+      const jymbo::types::QueryTree & q_tree_in,
+      jymbo::types::QueryTree & q_tree_out
    );
 }
 

--- a/derivative_tree/src/derivative_tree.cpp
+++ b/derivative_tree/src/derivative_tree.cpp
@@ -153,4 +153,13 @@ namespace derivative_tree
          }
       }
    }
+
+   void convertToQTree(
+      const jymbo::types::DerivativeTree & d_tree,
+      jymbo::types::QueryTree & q_tree
+   )
+   {
+      
+   }
+
 }

--- a/derivative_tree/src/derivative_tree.cpp
+++ b/derivative_tree/src/derivative_tree.cpp
@@ -202,7 +202,7 @@ namespace derivative_tree
             for (int i = 0; i < 2; ++i)
             {
                frontier.push_back(
-                  {src_node.childNodeIds[i], dest_node_id}
+                  {src_node.childNodeIds[i], new_dest_parent_id}
                );
             }
          }

--- a/derivative_tree/src/derivative_tree.cpp
+++ b/derivative_tree/src/derivative_tree.cpp
@@ -261,6 +261,9 @@ namespace derivative_tree
             // If we've found a reference to q Q node, then this node on the
             // d-tree is a leaf node, and we don't need to check if it has any
             // children.
+            const jymbo::types::queryNode_t ref_q_node = q_tree_in[d_node.meta.qNodeId];
+            const int dest_node_id = q_tree_out.addChild(copy_node.destParentNodeId, ref_q_node);
+            copyQTreeToQTree(d_node.meta.qNodeId, dest_node_id, q_tree_in, q_tree_out);
          }
          else
          {

--- a/derivative_tree/src/derivative_tree.cpp
+++ b/derivative_tree/src/derivative_tree.cpp
@@ -154,12 +154,58 @@ namespace derivative_tree
       }
    }
 
-   void convertToQTree(
-      const jymbo::types::DerivativeTree & d_tree,
-      jymbo::types::QueryTree & q_tree
+   jymbo::types::queryNode_t convertDNodeToQNode(
+      const jymbo::types::derivativeNode_t d_node,
+      const jymbo::types::QueryTree & q_tree_in
    )
    {
-      
+      jymbo::types::queryNode_t q_node;
+
+      switch(d_node.nodeType)
+      {
+         case jymbo::types::enumDerivativeNodeType_t::kOperator:
+            q_node.nodeType = jymbo::types::enumQueryNodeType_t::kOperator;
+            q_node.op = d_node.op;
+            break;
+         case jymbo::types::enumDerivativeNodeType_t::kReference:
+            q_node.nodeType = q_tree_in[d_node.qNodeId].nodeType;
+            switch(q_node.nodeType)
+            {
+               case jymbo::types::enumQueryNodeType_t::kOperator:
+                  q_node.op = q_tree_in[d_node.qNodeId].op;
+                  break;
+               case jymbo::types::enumQueryNodeType_t::kSymbol:
+                  q_node.symbol = q_tree_in[d_node.qNodeId].symbol;
+                  break;
+            }
+            break;
+         case jymbo::types::enumDerivativeNodeType_t::kSymbol:
+            q_node.nodeType = jymbo::types::enumQueryNodeType_t::kSymbol;
+            q_node.symbol = d_node.symbol;
+            break;
+      }
+
+      return q_node;
+   }
+
+   void convertToQTree(
+      const jymbo::types::DerivativeTree & d_tree,
+      const jymbo::types::QueryTree & q_tree_in,
+      jymbo::types::QueryTree & q_tree_out
+   )
+   {
+      std::vector<int> frontier;
+      frontier.reserve(d_tree.size() + q_tree_in.size());
+
+      frontier.push_back(d_tree.getRootId());
+
+      while (frontier.size() > 0)
+      {
+         const int d_node_id = frontier.back();
+         frontier.pop_back();
+
+
+      }
    }
 
 }

--- a/derivative_tree/src/derivative_tree.cpp
+++ b/derivative_tree/src/derivative_tree.cpp
@@ -174,12 +174,14 @@ namespace derivative_tree
             (src_node.childNodeIds[1] != -1)
          )
          {
-            for (int i = 0; i < 2; ++i)
-            {
-               frontier.push_back(
-                  {src_node.childNodeIds[i], dest_node_id}
-               );
-            }
+            // Have to do it in this order, otherwise the children have their
+            // positions swapped in the output tree.
+            frontier.push_back(
+               {src_node.childNodeIds[1], dest_node_id}
+            );
+            frontier.push_back(
+               {src_node.childNodeIds[0], dest_node_id}
+            );
          }
       }
 
@@ -199,12 +201,14 @@ namespace derivative_tree
             (src_node.childNodeIds[1] != -1)
          )
          {
-            for (int i = 0; i < 2; ++i)
-            {
-               frontier.push_back(
-                  {src_node.childNodeIds[i], new_dest_parent_id}
-               );
-            }
+            // Have to do it in this order, otherwise the children have their
+            // positions swapped in the output tree.
+            frontier.push_back(
+               {src_node.childNodeIds[1], new_dest_parent_id}
+            );
+            frontier.push_back(
+               {src_node.childNodeIds[0], new_dest_parent_id}
+            );
          }
       }
    }
@@ -242,12 +246,14 @@ namespace derivative_tree
 
       q_tree_out.setRoot(convertDNodeToQNode(d_tree[d_tree.getRootId()]));
 
-      for (int i = 0; i < 2; ++i)
-      {
-         frontier.push_back(
-            {d_tree.getRoot().childNodeIds[i], q_tree_out.getRootId()}
-         );
-      }
+      // Have to do it in this order, otherwise the children have their
+      // positions swapped in the output tree.
+      frontier.push_back(
+         {d_tree.getRoot().childNodeIds[1], q_tree_out.getRootId()}
+      );
+      frontier.push_back(
+         {d_tree.getRoot().childNodeIds[0], q_tree_out.getRootId()}
+      );
 
       while (frontier.size() > 0)
       {
@@ -278,17 +284,16 @@ namespace derivative_tree
                (d_tree_node.childNodeIds[1] != -1)
             )
             {
-               // Add the children of the d-tree and the destination parent
-               // node as new nodes on the frontier. Node, node, node, node.
-               for (int i = 0 ; i < 2; ++i)
-               {
-                  frontier.push_back(
-                     {d_tree_node.childNodeIds[i], new_dest_parent_node_id}
-                  );
-               }
+               // Have to do it in this order, otherwise the children have their
+               // positions swapped in the output tree.
+               frontier.push_back(
+                  {d_tree_node.childNodeIds[1], new_dest_parent_node_id}
+               );
+               frontier.push_back(
+                  {d_tree_node.childNodeIds[0], new_dest_parent_node_id}
+               );
             }
          }
-
       }
    }
 

--- a/operators/src/operators.cpp
+++ b/operators/src/operators.cpp
@@ -67,7 +67,6 @@ namespace jymbo
             );
             break;
          case jymbo::types::enumSymbolType_t::kConstant:
-         case jymbo::types::enumSymbolType_t::kIndependent:
          case jymbo::types::enumSymbolType_t::kParameter:
             d_node.symbol = jymbo::initializeSymbol(
                "0", -1, 0.f, jymbo::types::enumSymbolType_t::kConstant
@@ -77,6 +76,12 @@ namespace jymbo
             d_node.symbol = jymbo::initializeSymbol(
                "NULL", -1, 0.f, jymbo::types::enumSymbolType_t::kNull
             );
+            break;
+         case jymbo::types::enumSymbolType_t::kIndependent:
+            d_node.symbol = jymbo::initializeSymbol(
+               "1", 1, 0.f, jymbo::types::enumSymbolType_t::kConstant
+            );
+            break;
       }
 
       return {{-1, -1}};


### PR DESCRIPTION
## Features

- Adds a function to convert a derivative tree to a query tree
- Fixes a bug where the trivial derivative of an independent variable symbol was zero instead of one
- Adds a function that copies the subtree of one q-tree to another q-tree
- Adds converted q-trees to the existing derivative tests
  - It's not really a test, it just prints stuff

Closes #21 
