### PR TITLE
#24 - Add derivative subtrees for trig functions

### DIFF
--- a/jymbo/include/operators.hpp
+++ b/jymbo/include/operators.hpp
@@ -47,6 +47,24 @@ namespace jymbo
       jymbo::types::DerivativeTree & d_tree
    );
 
+   jymbo::types::derivativeFrontierNodes sineDerivativeSubtree(
+      const int d_node_id,
+      const jymbo::types::QueryTree & q_tree,
+      jymbo::types::DerivativeTree & d_tree
+   );
+
+   jymbo::types::derivativeFrontierNodes cosineDerivativeSubtree(
+      const int d_node_id,
+      const jymbo::types::QueryTree & q_tree,
+      jymbo::types::DerivativeTree & d_tree
+   );
+
+   jymbo::types::derivativeFrontierNodes tangentDerivativeSubtree(
+      const int d_node_id,
+      const jymbo::types::QueryTree & q_tree,
+      jymbo::types::DerivativeTree & d_tree
+   );
+
    class Derivatizer
    {
       public:

--- a/jymbo/include/operators.hpp
+++ b/jymbo/include/operators.hpp
@@ -89,7 +89,10 @@ namespace jymbo
             {jymbo::types::enumOperatorType_t::kSubtraction, subtractionDerivativeSubtree},
             {jymbo::types::enumOperatorType_t::kMultiplication, multiplicationDerivativeSubtree},
             {jymbo::types::enumOperatorType_t::kDivision, divisionDerivativeSubtree},
-            {jymbo::types::enumOperatorType_t::kPower, powerDerivativeSubtree}
+            {jymbo::types::enumOperatorType_t::kPower, powerDerivativeSubtree},
+            {jymbo::types::enumOperatorType_t::kSine, sineDerivativeSubtree},
+            {jymbo::types::enumOperatorType_t::kCosine, cosineDerivativeSubtree},
+            {jymbo::types::enumOperatorType_t::kTangent, tangentDerivativeSubtree}
          };
    };
 }

--- a/jymbo/src/operators.cpp
+++ b/jymbo/src/operators.cpp
@@ -539,12 +539,6 @@ namespace jymbo
          "-2", -2, -2.f, jymbo::types::enumSymbolType_t::kConstant
       );
 
-      jymbo::types::derivativeNode_t null_sym;
-      null_sym.nodeType = jymbo::types::enumDerivativeNodeType_t::kSymbol;
-      null_sym.symbol = jymbo::initializeSymbol(
-         "null", 0, 0.f, jymbo::types::enumSymbolType_t::kNull
-      );
-
       if (d_tree[d_node_id].nodeType != jymbo::types::enumDerivativeNodeType_t::kReference)
       {
          std::cout << "Derivative tree at node id " << d_node_id << " should reference the q-tree, but it doesn't\n";
@@ -579,7 +573,7 @@ namespace jymbo
       d_tree.addChild(pow_op_id, neg_2_const);
 
       d_tree.addChild(cos_op_id, left_q_ref);
-      d_tree.addChild(cos_op_id, null_sym);
+      d_tree.addChild(cos_op_id, right_q_ref);
 
       jymbo::types::derivativeFrontierNodes d_frontier = {
          left_frontier_node_id,

--- a/jymbo/src/operators.cpp
+++ b/jymbo/src/operators.cpp
@@ -430,7 +430,7 @@ namespace jymbo
       left_q_ref.nodeType = jymbo::types::enumDerivativeNodeType_t::kReference;
       left_q_ref.qNodeId = q_left_child_id;
 
-      // The right child of the sine operation should be a NULL symbol.
+      // The right child of the sine operation should be a null symbol.
       jymbo::types::derivativeNode_t right_q_ref;
       right_q_ref.nodeType = jymbo::types::enumDerivativeNodeType_t::kReference;
       right_q_ref.qNodeId = q_right_child_id;
@@ -521,7 +521,70 @@ namespace jymbo
       jymbo::types::DerivativeTree & d_tree
    )
    {
+      jymbo::types::derivativeNode_t mult_op;
+      mult_op.nodeType = jymbo::types::enumDerivativeNodeType_t::kOperator;
+      mult_op.op = jymbo::types::enumOperatorType_t::kMultiplication;
 
+      jymbo::types::derivativeNode_t pow_op;
+      pow_op.nodeType = jymbo::types::enumDerivativeNodeType_t::kOperator;
+      pow_op.op = jymbo::types::enumOperatorType_t::kPower;
+
+      jymbo::types::derivativeNode_t cos_op;
+      cos_op.nodeType = jymbo::types::enumDerivativeNodeType_t::kOperator;
+      cos_op.op = jymbo::types::enumOperatorType_t::kCosine;
+
+      jymbo::types::derivativeNode_t neg_2_const;
+      neg_2_const.nodeType = jymbo::types::enumDerivativeNodeType_t::kSymbol;
+      neg_2_const.symbol = jymbo::initializeSymbol(
+         "-2", -2, -2.f, jymbo::types::enumSymbolType_t::kConstant
+      );
+
+      jymbo::types::derivativeNode_t null_sym;
+      null_sym.nodeType = jymbo::types::enumDerivativeNodeType_t::kSymbol;
+      null_sym.symbol = jymbo::initializeSymbol(
+         "null", 0, 0.f, jymbo::types::enumSymbolType_t::kNull
+      );
+
+      if (d_tree[d_node_id].nodeType != jymbo::types::enumDerivativeNodeType_t::kReference)
+      {
+         std::cout << "Derivative tree at node id " << d_node_id << " should reference the q-tree, but it doesn't\n";
+         return {{-1, -1}};
+      }
+
+      const auto & q_node_ref = q_tree.getNode(d_tree[d_node_id].qNodeId);
+
+      const int q_left_child_id = q_node_ref.childNodeIds[0];
+      const int q_right_child_id = q_node_ref.childNodeIds[1];
+
+      if (q_left_child_id == -1 || q_right_child_id == -1)
+      {
+         return {{-1, -1}};
+      }
+
+      jymbo::types::derivativeNode_t left_q_ref;
+      left_q_ref.nodeType = jymbo::types::enumDerivativeNodeType_t::kReference;
+      left_q_ref.qNodeId = q_left_child_id;
+
+      // The right child of the tangent operation should be a null symbol.
+      jymbo::types::derivativeNode_t right_q_ref;
+      right_q_ref.nodeType = jymbo::types::enumDerivativeNodeType_t::kReference;
+      right_q_ref.qNodeId = q_right_child_id;
+
+      d_tree[d_node_id] = mult_op;
+
+      const int pow_op_id = d_tree.addChild(d_node_id, pow_op);
+      const int left_frontier_node_id = d_tree.addChild(d_node_id, left_q_ref);
+
+      const int cos_op_id = d_tree.addChild(pow_op_id, cos_op);
+      d_tree.addChild(cos_op_id, left_q_ref);
+      d_tree.addChild(cos_op_id, null_sym);
+
+      jymbo::types::derivativeFrontierNodes d_frontier = {
+         left_frontier_node_id,
+         -1
+      };
+
+      return d_frontier;
    }
 
    jymbo::types::derivativeFrontierNodes Derivatizer::operator()(

--- a/jymbo/src/operators.cpp
+++ b/jymbo/src/operators.cpp
@@ -396,6 +396,33 @@ namespace jymbo
       return d_frontier;
    }
 
+   jymbo::types::derivativeFrontierNodes sineDerivativeSubtree(
+      const int d_node_id,
+      const jymbo::types::QueryTree & q_tree,
+      jymbo::types::DerivativeTree & d_tree
+   )
+   {
+
+   }
+
+   jymbo::types::derivativeFrontierNodes cosineDerivativeSubtree(
+      const int d_node_id,
+      const jymbo::types::QueryTree & q_tree,
+      jymbo::types::DerivativeTree & d_tree
+   )
+   {
+
+   }
+
+   jymbo::types::derivativeFrontierNodes tangentDerivativeSubtree(
+      const int d_node_id,
+      const jymbo::types::QueryTree & q_tree,
+      jymbo::types::DerivativeTree & d_tree
+   )
+   {
+      
+   }
+
    jymbo::types::derivativeFrontierNodes Derivatizer::operator()(
       const int d_node_id,
       const jymbo::types::QueryTree & q_tree,

--- a/jymbo/src/operators.cpp
+++ b/jymbo/src/operators.cpp
@@ -576,6 +576,8 @@ namespace jymbo
       const int left_frontier_node_id = d_tree.addChild(d_node_id, left_q_ref);
 
       const int cos_op_id = d_tree.addChild(pow_op_id, cos_op);
+      d_tree.addChild(pow_op_id, neg_2_const);
+
       d_tree.addChild(cos_op_id, left_q_ref);
       d_tree.addChild(cos_op_id, null_sym);
 

--- a/tests/derivative_tree/derivative_tree_tests/derivative_tree_tests.cpp
+++ b/tests/derivative_tree/derivative_tree_tests/derivative_tree_tests.cpp
@@ -156,3 +156,56 @@ TEST_CASE( "take derivative of quadratic equation", "[DerivativeTree]" )
    std::cout << "givin you the parsed d tree\n";
    query_tree::print(derivative_of_q_tree);
 }
+
+TEST_CASE( "take derivative of sine", "[DerivativeTree]" )
+{
+   jymbo::types::queryNode_t q_node;
+   q_node.nodeType = jymbo::types::enumQueryNodeType_t::kOperator;
+   q_node.op = jymbo::types::enumOperatorType_t::kEqual;
+   jymbo::types::QueryTree q_tree(q_node);
+
+   jymbo::types::queryNode_t q_y_node;
+   q_y_node.nodeType = jymbo::types::enumQueryNodeType_t::kSymbol;
+   q_y_node.symbol = jymbo::initializeSymbol(
+      "y", 0, 0.f, jymbo::types::enumSymbolType_t::kDependent
+   );
+
+   jymbo::types::queryNode_t sin_op;
+   sin_op.nodeType = jymbo::types::enumQueryNodeType_t::kOperator;
+   sin_op.op = jymbo::types::enumOperatorType_t::kSine;
+
+   q_tree.addChild(q_tree.getRootId(), q_y_node);
+   const int sin_op_id = q_tree.addChild(q_tree.getRootId(), sin_op);
+
+   jymbo::types::queryNode_t x_sym_node;
+   x_sym_node.nodeType = jymbo::types::enumQueryNodeType_t::kSymbol;
+   x_sym_node.symbol = jymbo::initializeSymbol(
+      "x", 1, 0.f, jymbo::types::enumSymbolType_t::kIndependent
+   );
+
+   jymbo::types::queryNode_t null_sym;
+   null_sym.nodeType = jymbo::types::enumQueryNodeType_t::kSymbol;
+   null_sym.symbol = jymbo::initializeSymbol(
+      "null", 0, 0.f, jymbo::types::enumSymbolType_t::kNull
+   );
+
+   q_tree.addChild(sin_op_id, x_sym_node);
+   q_tree.addChild(sin_op_id, null_sym);
+
+   std::cout << "\na triggy boi\n";
+   query_tree::print(q_tree);
+
+   jymbo::types::derivativeNode_t d_node;
+   d_node.nodeType = jymbo::types::enumDerivativeNodeType_t::kOperator;
+   d_node.op = jymbo::types::enumOperatorType_t::kEqual;
+   jymbo::types::DerivativeTree d_tree(d_node);
+
+   derivative_tree::derivatize(q_tree, d_tree);
+
+   jymbo::types::QueryTree derivative_of_q_tree(q_node);
+
+   derivative_tree::convertToQTree(d_tree, q_tree, derivative_of_q_tree);
+
+   std::cout << "givin you the parsed d tree\n";
+   query_tree::print(derivative_of_q_tree);
+}

--- a/tests/derivative_tree/derivative_tree_tests/derivative_tree_tests.cpp
+++ b/tests/derivative_tree/derivative_tree_tests/derivative_tree_tests.cpp
@@ -209,3 +209,109 @@ TEST_CASE( "take derivative of sine", "[DerivativeTree]" )
    std::cout << "givin you the parsed d tree\n";
    query_tree::print(derivative_of_q_tree);
 }
+
+TEST_CASE( "take derivative of cosine", "[DerivativeTree]" )
+{
+   jymbo::types::queryNode_t q_node;
+   q_node.nodeType = jymbo::types::enumQueryNodeType_t::kOperator;
+   q_node.op = jymbo::types::enumOperatorType_t::kEqual;
+   jymbo::types::QueryTree q_tree(q_node);
+
+   jymbo::types::queryNode_t q_y_node;
+   q_y_node.nodeType = jymbo::types::enumQueryNodeType_t::kSymbol;
+   q_y_node.symbol = jymbo::initializeSymbol(
+      "y", 0, 0.f, jymbo::types::enumSymbolType_t::kDependent
+   );
+
+   jymbo::types::queryNode_t cos_op;
+   cos_op.nodeType = jymbo::types::enumQueryNodeType_t::kOperator;
+   cos_op.op = jymbo::types::enumOperatorType_t::kCosine;
+
+   q_tree.addChild(q_tree.getRootId(), q_y_node);
+   const int cos_op_id = q_tree.addChild(q_tree.getRootId(), cos_op);
+
+   jymbo::types::queryNode_t x_sym_node;
+   x_sym_node.nodeType = jymbo::types::enumQueryNodeType_t::kSymbol;
+   x_sym_node.symbol = jymbo::initializeSymbol(
+      "x", 1, 0.f, jymbo::types::enumSymbolType_t::kIndependent
+   );
+
+   jymbo::types::queryNode_t null_sym;
+   null_sym.nodeType = jymbo::types::enumQueryNodeType_t::kSymbol;
+   null_sym.symbol = jymbo::initializeSymbol(
+      "null", 0, 0.f, jymbo::types::enumSymbolType_t::kNull
+   );
+
+   q_tree.addChild(cos_op_id, x_sym_node);
+   q_tree.addChild(cos_op_id, null_sym);
+
+   std::cout << "\na triggy boi\n";
+   query_tree::print(q_tree);
+
+   jymbo::types::derivativeNode_t d_node;
+   d_node.nodeType = jymbo::types::enumDerivativeNodeType_t::kOperator;
+   d_node.op = jymbo::types::enumOperatorType_t::kEqual;
+   jymbo::types::DerivativeTree d_tree(d_node);
+
+   derivative_tree::derivatize(q_tree, d_tree);
+
+   jymbo::types::QueryTree derivative_of_q_tree(q_node);
+
+   derivative_tree::convertToQTree(d_tree, q_tree, derivative_of_q_tree);
+
+   std::cout << "givin you the parsed d tree\n";
+   query_tree::print(derivative_of_q_tree);
+}
+
+TEST_CASE( "take derivative of tangent", "[DerivativeTree]" )
+{
+   jymbo::types::queryNode_t q_node;
+   q_node.nodeType = jymbo::types::enumQueryNodeType_t::kOperator;
+   q_node.op = jymbo::types::enumOperatorType_t::kEqual;
+   jymbo::types::QueryTree q_tree(q_node);
+
+   jymbo::types::queryNode_t q_y_node;
+   q_y_node.nodeType = jymbo::types::enumQueryNodeType_t::kSymbol;
+   q_y_node.symbol = jymbo::initializeSymbol(
+      "y", 0, 0.f, jymbo::types::enumSymbolType_t::kDependent
+   );
+
+   jymbo::types::queryNode_t tan_op;
+   tan_op.nodeType = jymbo::types::enumQueryNodeType_t::kOperator;
+   tan_op.op = jymbo::types::enumOperatorType_t::kTangent;
+
+   q_tree.addChild(q_tree.getRootId(), q_y_node);
+   const int tan_op_id = q_tree.addChild(q_tree.getRootId(), tan_op);
+
+   jymbo::types::queryNode_t x_sym_node;
+   x_sym_node.nodeType = jymbo::types::enumQueryNodeType_t::kSymbol;
+   x_sym_node.symbol = jymbo::initializeSymbol(
+      "x", 1, 0.f, jymbo::types::enumSymbolType_t::kIndependent
+   );
+
+   jymbo::types::queryNode_t null_sym;
+   null_sym.nodeType = jymbo::types::enumQueryNodeType_t::kSymbol;
+   null_sym.symbol = jymbo::initializeSymbol(
+      "null", 0, 0.f, jymbo::types::enumSymbolType_t::kNull
+   );
+
+   q_tree.addChild(tan_op_id, x_sym_node);
+   q_tree.addChild(tan_op_id, null_sym);
+
+   std::cout << "\na triggy boi\n";
+   query_tree::print(q_tree);
+
+   jymbo::types::derivativeNode_t d_node;
+   d_node.nodeType = jymbo::types::enumDerivativeNodeType_t::kOperator;
+   d_node.op = jymbo::types::enumOperatorType_t::kEqual;
+   jymbo::types::DerivativeTree d_tree(d_node);
+
+   derivative_tree::derivatize(q_tree, d_tree);
+
+   jymbo::types::QueryTree derivative_of_q_tree(q_node);
+
+   derivative_tree::convertToQTree(d_tree, q_tree, derivative_of_q_tree);
+
+   std::cout << "givin you the parsed d tree\n";
+   query_tree::print(derivative_of_q_tree);
+}


### PR DESCRIPTION
## Features

- Adds derivative subtree calculations for sine, cosine, and tangent
- Adds basic print-out tests to show that the trees are derivatized correctly

Closes #24 
