### PR TITLE
#28 - Add query node initialization helper functions

### DIFF
--- a/jymbo/CMakeLists.txt
+++ b/jymbo/CMakeLists.txt
@@ -3,6 +3,7 @@ set(
    include/derivative_tree.hpp
    include/jymbo_types.hpp
    include/operators.hpp
+   include/query_node.hpp
    include/query_tree.hpp
    include/symbols.hpp
 )
@@ -11,6 +12,7 @@ set(
    sources
    src/derivative_tree.cpp
    src/operators.cpp
+   src/query_node.cpp
    src/query_tree.cpp
    src/symbols.cpp
 )

--- a/jymbo/include/query_node.hpp
+++ b/jymbo/include/query_node.hpp
@@ -1,0 +1,28 @@
+#ifndef QUERY_NODE_HEADER
+#define QUERY_NODE_HEADER
+
+#include "jymbo_types.hpp"
+
+namespace jymbo
+{
+   jymbo::types::queryNode_t initializeOperatorQueryNode(
+      const jymbo::types::enumOperatorType_t op
+   );
+
+   jymbo::types::queryNode_t initializeSymbolQueryNode(
+      const char * name,
+      const int uid,
+      const float val,
+      const jymbo::types::enumSymbolType_t symbol_type
+   );
+
+   jymbo::types::queryNode_t initializeSymbolQueryNode(
+      const char * name,
+      const int suffix,
+      const int uid,
+      const float val,
+      const jymbo::types::enumSymbolType_t symbol_type
+   );
+}
+
+#endif

--- a/jymbo/include/query_tree.hpp
+++ b/jymbo/include/query_tree.hpp
@@ -4,9 +4,6 @@
 #include "jymbo_types.hpp"
 #include "operators.hpp"
 
-#include <iostream>
-#include <string>
-
 namespace query_tree
 {
    struct printFrontierNode_t
@@ -23,73 +20,7 @@ namespace query_tree
       int childId;
    };
 
-   void print(const jymbo::types::QueryTree & q_tree)
-   {
-      std::string out_string;
-      std::vector<printFrontierNode_t> frontier;
-
-      frontier.reserve(q_tree.size());
-
-      const int root_node_id = q_tree.getRootId();
-
-      printFrontierNode_t root_frontier_node;
-      root_frontier_node.childId = 0;
-      root_frontier_node.parenthesesCount = 0;
-      root_frontier_node.nodeId = root_node_id;
-
-      frontier.push_back(root_frontier_node);
-
-      while (!frontier.empty())
-      {
-         const printFrontierNode_t frontier_node = frontier.back();
-         frontier.pop_back();
-
-         const jymbo::types::QueryTree::MetaNode_T & tree_node = \
-            q_tree.getNode(frontier_node.nodeId);
-
-         if (frontier_node.childId == 1)
-         {
-            out_string += std::string(",");
-         }
-
-         if (tree_node.meta.nodeType == jymbo::types::enumQueryNodeType_t::kOperator)
-         {
-            out_string += jymbo::operatorToString(tree_node.meta.op);
-            out_string += std::string("(");
-         }
-         else if (tree_node.meta.nodeType == jymbo::types::enumQueryNodeType_t::kSymbol)
-         {
-            out_string += std::string(tree_node.meta.symbol.name);
-         }
-
-         if (tree_node.childNodeIds[0] == -1 || tree_node.childNodeIds[1] == -1)
-         {
-            if (frontier_node.childId == 1)
-            {
-               for (int i = 0; i < frontier_node.parenthesesCount; ++i)
-               {
-                  out_string += std::string(")");
-               }
-            }
-            continue;
-         }
-
-         printFrontierNode_t left_frontier_node;
-         left_frontier_node.childId = 0;
-         left_frontier_node.parenthesesCount = 0;
-         left_frontier_node.nodeId = tree_node.childNodeIds[0];
-
-         printFrontierNode_t right_frontier_node;
-         right_frontier_node.childId = 1;
-         right_frontier_node.parenthesesCount = frontier_node.parenthesesCount + 1;
-         right_frontier_node.nodeId = tree_node.childNodeIds[1];
-
-         frontier.push_back(right_frontier_node);
-         frontier.push_back(left_frontier_node);
-      }
-
-      std::cout << out_string << "\n";
-   }
+   void print(const jymbo::types::QueryTree & q_tree);
 }
 
 #endif

--- a/jymbo/src/query_node.cpp
+++ b/jymbo/src/query_node.cpp
@@ -1,0 +1,49 @@
+#include "query_node.hpp"
+#include "symbols.hpp"
+
+namespace jymbo
+{
+   jymbo::types::queryNode_t initializeOperatorQueryNode(
+      const jymbo::types::enumOperatorType_t op
+   )
+   {
+      jymbo::types::queryNode_t op_node;
+      op_node.nodeType = jymbo::types::enumQueryNodeType_t::kOperator;
+      op_node.op = op;
+
+      return op_node;
+   }
+
+   jymbo::types::queryNode_t initializeSymbolQueryNode(
+      const char * name,
+      const int uid,
+      const float val,
+      const jymbo::types::enumSymbolType_t symbol_type
+   )
+   {
+      jymbo::types::queryNode_t sym_node;
+      sym_node.nodeType = jymbo::types::enumQueryNodeType_t::kSymbol;
+      sym_node.symbol = initializeSymbol(
+         name, uid, val, symbol_type
+      );
+
+      return sym_node;
+   }
+
+   jymbo::types::queryNode_t initializeSymbolQueryNode(
+      const char * name,
+      const int suffix,
+      const int uid,
+      const float val,
+      const jymbo::types::enumSymbolType_t symbol_type
+   )
+   {
+      jymbo::types::queryNode_t sym_node;
+      sym_node.nodeType = jymbo::types::enumQueryNodeType_t::kSymbol;
+      sym_node.symbol = initializeSymbol(
+         name, suffix, uid, val, symbol_type
+      );
+
+      return sym_node;
+   }
+}

--- a/jymbo/src/query_tree.cpp
+++ b/jymbo/src/query_tree.cpp
@@ -1,0 +1,75 @@
+#include "query_tree.hpp"
+
+#include <iostream>
+#include <string>
+
+namespace query_tree
+{
+   void print(const jymbo::types::QueryTree & q_tree)
+   {
+      std::string out_string;
+      std::vector<printFrontierNode_t> frontier;
+
+      frontier.reserve(q_tree.size());
+
+      const int root_node_id = q_tree.getRootId();
+
+      printFrontierNode_t root_frontier_node;
+      root_frontier_node.childId = 0;
+      root_frontier_node.parenthesesCount = 0;
+      root_frontier_node.nodeId = root_node_id;
+
+      frontier.push_back(root_frontier_node);
+
+      while (!frontier.empty())
+      {
+         const printFrontierNode_t frontier_node = frontier.back();
+         frontier.pop_back();
+
+         const jymbo::types::QueryTree::MetaNode_T & tree_node = \
+            q_tree.getNode(frontier_node.nodeId);
+
+         if (frontier_node.childId == 1)
+         {
+            out_string += std::string(",");
+         }
+
+         if (tree_node.meta.nodeType == jymbo::types::enumQueryNodeType_t::kOperator)
+         {
+            out_string += jymbo::operatorToString(tree_node.meta.op);
+            out_string += std::string("(");
+         }
+         else if (tree_node.meta.nodeType == jymbo::types::enumQueryNodeType_t::kSymbol)
+         {
+            out_string += std::string(tree_node.meta.symbol.name);
+         }
+
+         if (tree_node.childNodeIds[0] == -1 || tree_node.childNodeIds[1] == -1)
+         {
+            if (frontier_node.childId == 1)
+            {
+               for (int i = 0; i < frontier_node.parenthesesCount; ++i)
+               {
+                  out_string += std::string(")");
+               }
+            }
+            continue;
+         }
+
+         printFrontierNode_t left_frontier_node;
+         left_frontier_node.childId = 0;
+         left_frontier_node.parenthesesCount = 0;
+         left_frontier_node.nodeId = tree_node.childNodeIds[0];
+
+         printFrontierNode_t right_frontier_node;
+         right_frontier_node.childId = 1;
+         right_frontier_node.parenthesesCount = frontier_node.parenthesesCount + 1;
+         right_frontier_node.nodeId = tree_node.childNodeIds[1];
+
+         frontier.push_back(right_frontier_node);
+         frontier.push_back(left_frontier_node);
+      }
+
+      std::cout << out_string << "\n";
+   }
+}

--- a/tests/derivative_tree/derivative_tree_tests/derivative_tree_tests.cpp
+++ b/tests/derivative_tree/derivative_tree_tests/derivative_tree_tests.cpp
@@ -1,6 +1,7 @@
 #include "jymbo_types.hpp"
 #include "derivative_tree.hpp"
 #include "polynomial_query_tree.hpp"
+#include "query_node.hpp"
 #include "query_tree.hpp"
 #include "symbols.hpp"
 
@@ -52,30 +53,25 @@ TEST_CASE( "print derivative tree", "[DerivativeTree]" )
 
 TEST_CASE( "take derivative of multiplication", "[DerivativeTree]" )
 {
-   jymbo::types::queryNode_t q_node;
-   q_node.nodeType = jymbo::types::enumQueryNodeType_t::kOperator;
-   q_node.op = jymbo::types::enumOperatorType_t::kEqual;
+   jymbo::types::queryNode_t q_node = jymbo::initializeOperatorQueryNode(
+      jymbo::types::enumOperatorType_t::kEqual
+   );
+
    jymbo::types::QueryTree q_tree(q_node);
 
-   jymbo::types::queryNode_t q_y_node;
-   q_y_node.nodeType = jymbo::types::enumQueryNodeType_t::kSymbol;
-   q_y_node.symbol = jymbo::initializeSymbol(
+   jymbo::types::queryNode_t q_y_node = jymbo::initializeSymbolQueryNode(
       "y", 0, 0.f, jymbo::types::enumSymbolType_t::kDependent
    );
 
-   jymbo::types::queryNode_t mult_op;
-   mult_op.nodeType = jymbo::types::enumQueryNodeType_t::kOperator;
-   mult_op.op = jymbo::types::enumOperatorType_t::kMultiplication;
+   jymbo::types::queryNode_t mult_op = jymbo::initializeOperatorQueryNode(
+      jymbo::types::enumOperatorType_t::kMultiplication
+   );
 
-   jymbo::types::queryNode_t q_x_node;
-   q_x_node.nodeType = jymbo::types::enumQueryNodeType_t::kSymbol;
-   q_x_node.symbol = jymbo::initializeSymbol(
+   jymbo::types::queryNode_t q_x_node = jymbo::initializeSymbolQueryNode(
       "x", 0, 0.f, jymbo::types::enumSymbolType_t::kIndependent
    );
 
-   jymbo::types::queryNode_t q_a_node;
-   q_a_node.nodeType = jymbo::types::enumQueryNodeType_t::kSymbol;
-   q_a_node.symbol = jymbo::initializeSymbol(
+   jymbo::types::queryNode_t q_a_node = jymbo::initializeSymbolQueryNode(
       "a", 0, 0.f, jymbo::types::enumSymbolType_t::kParameter
    );
 
@@ -99,9 +95,10 @@ TEST_CASE( "take derivative of multiplication", "[DerivativeTree]" )
 
 TEST_CASE( "take derivative of linear equation", "[DerivativeTree]" )
 {
-   jymbo::types::queryNode_t q_node;
-   q_node.nodeType = jymbo::types::enumQueryNodeType_t::kOperator;
-   q_node.op = jymbo::types::enumOperatorType_t::kEqual;
+   jymbo::types::queryNode_t q_node = jymbo::initializeOperatorQueryNode(
+      jymbo::types::enumOperatorType_t::kEqual
+   );
+
    jymbo::types::QueryTree q_tree(q_node);
 
    test_utils::polynomialQueryTree(1, q_tree);
@@ -130,9 +127,10 @@ TEST_CASE( "take derivative of linear equation", "[DerivativeTree]" )
 
 TEST_CASE( "take derivative of quadratic equation", "[DerivativeTree]" )
 {
-   jymbo::types::queryNode_t q_node;
-   q_node.nodeType = jymbo::types::enumQueryNodeType_t::kOperator;
-   q_node.op = jymbo::types::enumOperatorType_t::kEqual;
+   jymbo::types::queryNode_t q_node = jymbo::initializeOperatorQueryNode(
+      jymbo::types::enumOperatorType_t::kEqual
+   );
+
    jymbo::types::QueryTree q_tree(q_node);
 
    test_utils::polynomialQueryTree(2, q_tree);
@@ -159,33 +157,28 @@ TEST_CASE( "take derivative of quadratic equation", "[DerivativeTree]" )
 
 TEST_CASE( "take derivative of sine", "[DerivativeTree]" )
 {
-   jymbo::types::queryNode_t q_node;
-   q_node.nodeType = jymbo::types::enumQueryNodeType_t::kOperator;
-   q_node.op = jymbo::types::enumOperatorType_t::kEqual;
+   jymbo::types::queryNode_t q_node = jymbo::initializeOperatorQueryNode(
+      jymbo::types::enumOperatorType_t::kEqual
+   );
+
    jymbo::types::QueryTree q_tree(q_node);
 
-   jymbo::types::queryNode_t q_y_node;
-   q_y_node.nodeType = jymbo::types::enumQueryNodeType_t::kSymbol;
-   q_y_node.symbol = jymbo::initializeSymbol(
+   jymbo::types::queryNode_t q_y_node = jymbo::initializeSymbolQueryNode(
       "y", 0, 0.f, jymbo::types::enumSymbolType_t::kDependent
    );
 
-   jymbo::types::queryNode_t sin_op;
-   sin_op.nodeType = jymbo::types::enumQueryNodeType_t::kOperator;
-   sin_op.op = jymbo::types::enumOperatorType_t::kSine;
+   jymbo::types::queryNode_t sin_op = jymbo::initializeOperatorQueryNode(
+      jymbo::types::enumOperatorType_t::kSine
+   );
 
    q_tree.addChild(q_tree.getRootId(), q_y_node);
    const int sin_op_id = q_tree.addChild(q_tree.getRootId(), sin_op);
 
-   jymbo::types::queryNode_t x_sym_node;
-   x_sym_node.nodeType = jymbo::types::enumQueryNodeType_t::kSymbol;
-   x_sym_node.symbol = jymbo::initializeSymbol(
+   jymbo::types::queryNode_t x_sym_node = jymbo::initializeSymbolQueryNode(
       "x", 1, 0.f, jymbo::types::enumSymbolType_t::kIndependent
    );
 
-   jymbo::types::queryNode_t null_sym;
-   null_sym.nodeType = jymbo::types::enumQueryNodeType_t::kSymbol;
-   null_sym.symbol = jymbo::initializeSymbol(
+   jymbo::types::queryNode_t null_sym = jymbo::initializeSymbolQueryNode(
       "null", 0, 0.f, jymbo::types::enumSymbolType_t::kNull
    );
 
@@ -212,33 +205,28 @@ TEST_CASE( "take derivative of sine", "[DerivativeTree]" )
 
 TEST_CASE( "take derivative of cosine", "[DerivativeTree]" )
 {
-   jymbo::types::queryNode_t q_node;
-   q_node.nodeType = jymbo::types::enumQueryNodeType_t::kOperator;
-   q_node.op = jymbo::types::enumOperatorType_t::kEqual;
+   jymbo::types::queryNode_t q_node = jymbo::initializeOperatorQueryNode(
+      jymbo::types::enumOperatorType_t::kEqual
+   );
+
    jymbo::types::QueryTree q_tree(q_node);
 
-   jymbo::types::queryNode_t q_y_node;
-   q_y_node.nodeType = jymbo::types::enumQueryNodeType_t::kSymbol;
-   q_y_node.symbol = jymbo::initializeSymbol(
+   jymbo::types::queryNode_t q_y_node = jymbo::initializeSymbolQueryNode(
       "y", 0, 0.f, jymbo::types::enumSymbolType_t::kDependent
    );
 
-   jymbo::types::queryNode_t cos_op;
-   cos_op.nodeType = jymbo::types::enumQueryNodeType_t::kOperator;
-   cos_op.op = jymbo::types::enumOperatorType_t::kCosine;
+   jymbo::types::queryNode_t cos_op = jymbo::initializeOperatorQueryNode(
+      jymbo::types::enumOperatorType_t::kCosine
+   );
 
    q_tree.addChild(q_tree.getRootId(), q_y_node);
    const int cos_op_id = q_tree.addChild(q_tree.getRootId(), cos_op);
 
-   jymbo::types::queryNode_t x_sym_node;
-   x_sym_node.nodeType = jymbo::types::enumQueryNodeType_t::kSymbol;
-   x_sym_node.symbol = jymbo::initializeSymbol(
+   jymbo::types::queryNode_t x_sym_node = jymbo::initializeSymbolQueryNode(
       "x", 1, 0.f, jymbo::types::enumSymbolType_t::kIndependent
    );
 
-   jymbo::types::queryNode_t null_sym;
-   null_sym.nodeType = jymbo::types::enumQueryNodeType_t::kSymbol;
-   null_sym.symbol = jymbo::initializeSymbol(
+   jymbo::types::queryNode_t null_sym = jymbo::initializeSymbolQueryNode(
       "null", 0, 0.f, jymbo::types::enumSymbolType_t::kNull
    );
 
@@ -265,33 +253,28 @@ TEST_CASE( "take derivative of cosine", "[DerivativeTree]" )
 
 TEST_CASE( "take derivative of tangent", "[DerivativeTree]" )
 {
-   jymbo::types::queryNode_t q_node;
-   q_node.nodeType = jymbo::types::enumQueryNodeType_t::kOperator;
-   q_node.op = jymbo::types::enumOperatorType_t::kEqual;
+   jymbo::types::queryNode_t q_node = jymbo::initializeOperatorQueryNode(
+      jymbo::types::enumOperatorType_t::kEqual
+   );
+
    jymbo::types::QueryTree q_tree(q_node);
 
-   jymbo::types::queryNode_t q_y_node;
-   q_y_node.nodeType = jymbo::types::enumQueryNodeType_t::kSymbol;
-   q_y_node.symbol = jymbo::initializeSymbol(
+   jymbo::types::queryNode_t q_y_node = jymbo::initializeSymbolQueryNode(
       "y", 0, 0.f, jymbo::types::enumSymbolType_t::kDependent
    );
 
-   jymbo::types::queryNode_t tan_op;
-   tan_op.nodeType = jymbo::types::enumQueryNodeType_t::kOperator;
-   tan_op.op = jymbo::types::enumOperatorType_t::kTangent;
+   jymbo::types::queryNode_t tan_op = jymbo::initializeOperatorQueryNode(
+      jymbo::types::enumOperatorType_t::kTangent
+   );
 
    q_tree.addChild(q_tree.getRootId(), q_y_node);
    const int tan_op_id = q_tree.addChild(q_tree.getRootId(), tan_op);
 
-   jymbo::types::queryNode_t x_sym_node;
-   x_sym_node.nodeType = jymbo::types::enumQueryNodeType_t::kSymbol;
-   x_sym_node.symbol = jymbo::initializeSymbol(
+   jymbo::types::queryNode_t x_sym_node = jymbo::initializeSymbolQueryNode(
       "x", 1, 0.f, jymbo::types::enumSymbolType_t::kIndependent
    );
 
-   jymbo::types::queryNode_t null_sym;
-   null_sym.nodeType = jymbo::types::enumQueryNodeType_t::kSymbol;
-   null_sym.symbol = jymbo::initializeSymbol(
+   jymbo::types::queryNode_t null_sym = jymbo::initializeSymbolQueryNode(
       "null", 0, 0.f, jymbo::types::enumSymbolType_t::kNull
    );
 

--- a/tests/query_tree/query_tree_tests/query_tree_tests.cpp
+++ b/tests/query_tree/query_tree_tests/query_tree_tests.cpp
@@ -1,7 +1,7 @@
 #include "jymbo_types.hpp"
 
 #include "polynomial_query_tree.hpp"
-
+#include "query_node.hpp"
 #include "query_tree.hpp"
 
 #define CATCH_CONFIG_MAIN
@@ -10,18 +10,20 @@
 
 TEST_CASE( "query_tree_instantiation", "[QueryTree]" )
 {
-   jymbo::types::queryNode_t q_node;
-   q_node.nodeType = jymbo::types::enumQueryNodeType_t::kOperator;
-   q_node.op = jymbo::types::enumOperatorType_t::kEqual;
+   jymbo::types::queryNode_t q_node = jymbo::initializeOperatorQueryNode(
+      jymbo::types::enumOperatorType_t::kEqual
+   );
+
    jymbo::types::QueryTree q_tree(q_node);
    REQUIRE( true );
 }
 
 TEST_CASE( "quadratic tree instantiation", "[QueryTree]")
 {
-   jymbo::types::queryNode_t q_node;
-   q_node.nodeType = jymbo::types::enumQueryNodeType_t::kOperator;
-   q_node.op = jymbo::types::enumOperatorType_t::kEqual;
+   jymbo::types::queryNode_t q_node = jymbo::initializeOperatorQueryNode(
+      jymbo::types::enumOperatorType_t::kEqual
+   );
+
    jymbo::types::QueryTree q_tree(q_node);
 
    test_utils::polynomialQueryTree(2, q_tree);
@@ -33,9 +35,10 @@ TEST_CASE( "quadratic tree instantiation", "[QueryTree]")
 
 TEST_CASE( "cubic tree instantiation", "[QueryTree]")
 {
-   jymbo::types::queryNode_t q_node;
-   q_node.nodeType = jymbo::types::enumQueryNodeType_t::kOperator;
-   q_node.op = jymbo::types::enumOperatorType_t::kEqual;
+   jymbo::types::queryNode_t q_node = jymbo::initializeOperatorQueryNode(
+      jymbo::types::enumOperatorType_t::kEqual
+   );
+
    jymbo::types::QueryTree q_tree(q_node);
 
    test_utils::polynomialQueryTree(3, q_tree);

--- a/tests/test_utils/polynomial_query_tree.cpp
+++ b/tests/test_utils/polynomial_query_tree.cpp
@@ -1,4 +1,5 @@
 #include "polynomial_query_tree.hpp"
+#include "query_node.hpp"
 #include "symbols.hpp"
 
 #include <cstdio>
@@ -13,23 +14,19 @@ namespace test_utils
       jymbo::types::QueryTree & q_tree
    )
    {
-      jymbo::types::queryNode_t mult_op_node;
-      mult_op_node.nodeType = jymbo::types::enumQueryNodeType_t::kOperator;
-      mult_op_node.op = jymbo::types::enumOperatorType_t::kMultiplication;
+      jymbo::types::queryNode_t mult_op_node = jymbo::initializeOperatorQueryNode(
+         jymbo::types::enumOperatorType_t::kMultiplication
+      );
 
-      jymbo::types::queryNode_t pow_op_node;
-      pow_op_node.nodeType = jymbo::types::enumQueryNodeType_t::kOperator;
-      pow_op_node.op = jymbo::types::enumOperatorType_t::kPower;
+      jymbo::types::queryNode_t pow_op_node = jymbo::initializeOperatorQueryNode(
+         jymbo::types::enumOperatorType_t::kPower
+      );
 
-      jymbo::types::queryNode_t an_sym_node;
-      an_sym_node.nodeType = jymbo::types::enumQueryNodeType_t::kSymbol;
-      an_sym_node.symbol = jymbo::initializeSymbol(
+      jymbo::types::queryNode_t an_sym_node = jymbo::initializeSymbolQueryNode(
          "a", n, 2 * n + 5, 0.f, jymbo::types::enumSymbolType_t::kParameter
       );
 
-      jymbo::types::queryNode_t n_sym_node;
-      n_sym_node.nodeType = jymbo::types::enumQueryNodeType_t::kSymbol;
-      n_sym_node.symbol = jymbo::initializeSymbol(
+      jymbo::types::queryNode_t n_sym_node = jymbo::initializeSymbolQueryNode(
          "", n, 3 * n + 5, static_cast<float>(n), jymbo::types::enumSymbolType_t::kParameter
       );
 
@@ -43,36 +40,29 @@ namespace test_utils
 
    void polynomialQueryTree(const int n, jymbo::types::QueryTree & q_tree)
    {
-      (void)n;
-      jymbo::types::queryNode_t q_root_node;
-      q_root_node.nodeType = jymbo::types::enumQueryNodeType_t::kOperator;
-      q_root_node.op = jymbo::types::enumOperatorType_t::kEqual;
+      jymbo::types::queryNode_t q_root_node = jymbo::initializeOperatorQueryNode(
+         jymbo::types::enumOperatorType_t::kEqual
+      );
 
       q_tree.setRoot(q_root_node);
 
-      jymbo::types::queryNode_t q_y_node;
-      q_y_node.nodeType = jymbo::types::enumQueryNodeType_t::kSymbol;
-      q_y_node.symbol = jymbo::initializeSymbol(
+      jymbo::types::queryNode_t q_y_node = jymbo::initializeSymbolQueryNode(
          "y", 0, 0.f, jymbo::types::enumSymbolType_t::kDependent
       );
 
-      jymbo::types::queryNode_t plus_op_node;
-      plus_op_node.nodeType = jymbo::types::enumQueryNodeType_t::kOperator;
-      plus_op_node.op = jymbo::types::enumOperatorType_t::kAddition;
+      jymbo::types::queryNode_t plus_op_node = jymbo::initializeOperatorQueryNode(
+         jymbo::types::enumOperatorType_t::kAddition
+      );
 
       q_tree.addChild(q_tree.getRootId(), q_y_node);
 
       int plus_node_id = q_tree.addChild(q_tree.getRootId(), plus_op_node);
 
-      jymbo::types::queryNode_t x_sym_node;
-      x_sym_node.nodeType = jymbo::types::enumQueryNodeType_t::kSymbol;
-      x_sym_node.symbol = jymbo::initializeSymbol(
+      jymbo::types::queryNode_t x_sym_node = jymbo::initializeSymbolQueryNode(
          "x", 1, 0.f, jymbo::types::enumSymbolType_t::kIndependent
       );
 
-      jymbo::types::queryNode_t a0_sym_node;
-      a0_sym_node.nodeType = jymbo::types::enumQueryNodeType_t::kSymbol;
-      a0_sym_node.symbol = jymbo::initializeSymbol(
+      jymbo::types::queryNode_t a0_sym_node = jymbo::initializeSymbolQueryNode(
          "a0", 2, 0.f, jymbo::types::enumSymbolType_t::kParameter
       );
 


### PR DESCRIPTION
## Features

- Adds functions for initializing query nodes that are symbols or operators
- Updates all of the tests to use the helper functions
- Updates the test utils for polynomial generation to use the helper functions

Closes #28 
